### PR TITLE
[MOYEO-67] 플레이어 페이지 이슈 처리 

### DIFF
--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -161,10 +161,15 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
       // @note: 조정 라운드라면 선택되지 못한 사람들을 전부 보여준다.
       if (teamBuildingInfo?.roundStatus === 'ADJUSTED_ROUND')
         return user.joinedTeamUuid === null;
+      // @note: 1. 현재 라운드에서 선택할 수 있는 사람들
+      // @note: 2. 이번 라운드에서 선택된 사람들
       else
         return (
-          user.choices[activeStep] === teamUuid &&
-          (user.joinedTeamUuid === null || user.joinedTeamUuid === teamUuid)
+          (user.choices[activeStep] === teamUuid &&
+            user.joinedTeamUuid === null) ||
+          (!!user.selectedRound &&
+            ROUND_INDEX_MAP[user.selectedRound] === activeStep &&
+            user.joinedTeamUuid === teamUuid)
         );
     });
   }, [activeStep, teamBuildingInfo?.roundStatus, teamUuid, userInfoList]);

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -166,8 +166,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
         return (
           (user.choices[activeStep] === teamUuid &&
             user.joinedTeamUuid === null) ||
-          (!!user.selectedRound &&
-            ROUND_INDEX_MAP[user.selectedRound] === activeStep &&
+          (user.selectedRound === teamBuildingInfo?.roundStatus &&
             user.joinedTeamUuid === teamUuid)
         );
     });

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
-import toast from 'react-hot-toast';
 
 import { useSelectUsers } from '@/apis/team-building/mutations';
 import { useGetTotalInfo } from '@/apis/team-building/queries';


### PR DESCRIPTION
## 작업 내용

-SSE event handler 내부에서 round 변수를 사용하지 않도록 setTotalInfo가 아닌 refetch로 변경
-팀원 선택 요청(POST)후 success시 refetch (setTotalInfo로 하려했지만, 로직이 복잡해져서 refetch로 수정)
-라운드별 선택할 수 있는 + 이번 라운드에서 선택한 유저 필더링 조건 수정
-> 지망을 중복 투표할 경우, 이전 라운드에서 이미 선택된 유저가 또 보여지는 경우가 있음

+) 추가
-조정라운드에서 내 팀에 새로운 유저가 배정되면 알람뜨게

## 체크리스트

- [x] Code Review 요청
- [x] Label 설정
- [x] PR 제목 규칙에 맞는지 확인
