### PR TITLE
fix: 라운드 시작할 때, 팀빌딩 끝날 때 수정

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -49,7 +49,7 @@ const square = cva({
   variants: {
     visual: {
       first: {
-        backgroundColor: 'purple.80',
+        backgroundColor: 'purple.40',
       },
       second: {
         backgroundColor: 'purple.50',

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
-export const useDisclosure = () => {
-  const [isOpen, setIsOpen] = useState(false);
+export const useDisclosure = (open?: boolean) => {
+  const [isOpen, setIsOpen] = useState(open ?? false);
 
   return useMemo(
     () => ({

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 
-export const useDisclosure = (open?: boolean) => {
-  const [isOpen, setIsOpen] = useState(open ?? false);
+export const useDisclosure = () => {
+  const [isOpen, setIsOpen] = useState(false);
 
   return useMemo(
     () => ({

--- a/src/modals/OverallStatusModal.tsx
+++ b/src/modals/OverallStatusModal.tsx
@@ -9,7 +9,6 @@ import { Modal } from '@/components/Modal';
 import { css } from '@/styled-system/css';
 import { center, hstack, vstack } from '@/styled-system/patterns';
 import { Team, User } from '@/types';
-import { playSound } from '@/utils/sound';
 
 type OverallStatusModalProps = {
   isOpen: boolean;

--- a/src/modals/OverallStatusModal.tsx
+++ b/src/modals/OverallStatusModal.tsx
@@ -92,15 +92,8 @@ export const OverallStatusModal = ({
     );
   };
 
-  const onClickClose = () => {
-    // @note: 팀 빌딩이 끝났으면 못닫게 막기
-    if (data?.teamBuildingInfo?.roundStatus === 'COMPLETE') return;
-    playSound('버튼_클릭');
-    onClose();
-  };
-
   return (
-    <Modal isOpen={isOpen} onClose={onClickClose}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <section
         className={vstack({
           width: '100%',
@@ -130,7 +123,7 @@ export const OverallStatusModal = ({
             팀 빌딩 현황
           </h2>
           <CloseIcon
-            onClick={onClickClose}
+            onClick={onClose}
             className={css({ width: '40px', cursor: 'pointer' })}
           />
         </div>

--- a/src/modals/OverallStatusModal.tsx
+++ b/src/modals/OverallStatusModal.tsx
@@ -93,6 +93,7 @@ export const OverallStatusModal = ({
   };
 
   const onClickClose = () => {
+    // @note: 팀 빌딩이 끝났으면 못닫게 막기
     if (data?.teamBuildingInfo?.roundStatus === 'COMPLETE') return;
     playSound('버튼_클릭');
     onClose();

--- a/src/modals/OverallStatusModal.tsx
+++ b/src/modals/OverallStatusModal.tsx
@@ -92,8 +92,14 @@ export const OverallStatusModal = ({
     );
   };
 
+  const onClickClose = () => {
+    if (data?.teamBuildingInfo?.roundStatus === 'COMPLETE') return;
+    playSound('버튼_클릭');
+    onClose();
+  };
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClickClose}>
       <section
         className={vstack({
           width: '100%',
@@ -123,10 +129,7 @@ export const OverallStatusModal = ({
             팀 빌딩 현황
           </h2>
           <CloseIcon
-            onClick={() => {
-              playSound('버튼_클릭');
-              onClose();
-            }}
+            onClick={onClickClose}
             className={css({ width: '40px', cursor: 'pointer' })}
           />
         </div>

--- a/src/pages/Survey/SurveyForm.tsx
+++ b/src/pages/Survey/SurveyForm.tsx
@@ -186,7 +186,7 @@ export const SurveyForm = ({
         <FormControl label="소개 페이지(선택)">
           <input
             name="userProfile"
-            placeholder="Github, Behance, Instagram 등"
+            placeholder="노션 자기소개 페이지 혹은 개인 웹사이트 등"
             maxLength={MAX_LENGTH__USER_PROFILE}
             autoComplete="off"
             value={inputs.userProfile}

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -85,7 +85,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     else return `${ROUND_LABEL_MAP[roundStatus]}\n선택 완료하기`;
   }, [selectDoneList, teamUuid, activeStep, teamBuildingInfo?.roundStatus]);
 
-  const selectListModalProps = useDisclosure(true);
+  const selectListModalProps = useDisclosure();
   const roundStartModalProps = useDisclosure(); // 라운드 시작 모달
   const selectConfirmModalProps = useDisclosure(); // 선택 확인용 모달
   const agreementModalProps = useDisclosure(); // 동의서 모달
@@ -102,13 +102,19 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     if (!localStorage.getItem('agreement')) return;
 
     // @note: 조정라운드와 완료라운드는 전체 현황보기 모달이 자동으로 열린다.
+    // 첫번째 라운드에서는 선택 리스트 모달이 자동으로 열린다.
     if (teamBuildingInfo?.roundStatus === 'COMPLETE') {
       overallModalProps.onOpen();
       playSound('팀빌딩_완료');
     } else if (teamBuildingInfo?.roundStatus === 'ADJUSTED_ROUND') {
       overallModalProps.onOpen();
       playSound('라운드_변경');
-    } else playSound('라운드_변경');
+    } else {
+      if (teamBuildingInfo?.roundStatus === 'FIRST_ROUND') {
+        selectListModalProps.onOpen();
+      }
+      playSound('라운드_변경');
+    }
 
     roundStartModalProps.onOpen();
   }, [teamBuildingInfo?.roundStatus]);
@@ -228,6 +234,13 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
   const onClickAgreement = () => {
     localStorage.setItem('agreement', 'true');
     roundStartModalProps.onOpen();
+  };
+
+  const onClickOverallStatusModalClose = () => {
+    // @note: 팀 빌딩이 끝났으면 못닫게 막기
+    if (data?.teamBuildingInfo?.roundStatus === 'COMPLETE') return;
+    playSound('버튼_클릭');
+    overallModalProps.onClose();
   };
 
   return (
@@ -543,7 +556,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
       />
       <OverallStatusModal
         isOpen={overallModalProps.isOpen}
-        onClose={overallModalProps.onClose}
+        onClose={onClickOverallStatusModalClose}
         teamBuildingUuid={teamBuildingUuid}
       />
       <RoundStartModal

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -85,7 +85,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     else return `${ROUND_LABEL_MAP[roundStatus]}\n선택 완료하기`;
   }, [selectDoneList, teamUuid, activeStep, teamBuildingInfo?.roundStatus]);
 
-  const selectListModalProps = useDisclosure();
+  const selectListModalProps = useDisclosure(true);
   const roundStartModalProps = useDisclosure(); // 라운드 시작 모달
   const selectConfirmModalProps = useDisclosure(); // 선택 확인용 모달
   const agreementModalProps = useDisclosure(); // 동의서 모달

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -101,9 +101,13 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     // 별도의 effect 훅으로 토스트를 띄운다.
     if (!localStorage.getItem('agreement')) return;
 
+    // @note: 조정라운드와 완료라운드는 전체 현황보기 모달이 자동으로 열린다.
     if (teamBuildingInfo?.roundStatus === 'COMPLETE') {
       overallModalProps.onOpen();
       playSound('팀빌딩_완료');
+    } else if (teamBuildingInfo?.roundStatus === 'ADJUSTED_ROUND') {
+      overallModalProps.onOpen();
+      playSound('라운드_변경');
     } else playSound('라운드_변경');
 
     roundStartModalProps.onOpen();

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -101,8 +101,10 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     // 별도의 effect 훅으로 토스트를 띄운다.
     if (!localStorage.getItem('agreement')) return;
 
-    if (teamBuildingInfo?.roundStatus === 'COMPLETE') playSound('팀빌딩_완료');
-    else playSound('라운드_변경');
+    if (teamBuildingInfo?.roundStatus === 'COMPLETE') {
+      overallModalProps.onOpen();
+      playSound('팀빌딩_완료');
+    } else playSound('라운드_변경');
 
     roundStartModalProps.onOpen();
   }, [teamBuildingInfo?.roundStatus]);


### PR DESCRIPTION
## 작업 내용

- 라운드 시작할 때 현황 보기 리스트 open상태로 시작하게 수정
- 팀 구성 조정 라운드에서 전체 현황보기 보여지게 수정 (삭제는 됨)
- 팀빌딩 끝나고 전체 현황보기 보여지게 수정 (삭제 안되게)
- chip 색상 수정

## 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
- [ ] PR 제목 규칙에 맞는지 확인
