### PR TITLE
fix: 생각나는대로 이것저것 수정

### DIFF
--- a/src/hooks/useBeforeUnload.ts
+++ b/src/hooks/useBeforeUnload.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export const useBeforeUnload = (when: boolean = true) => {
+  useEffect(() => {
+    if (!when) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = true;
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [when]);
+};

--- a/src/layouts/CommonLayout.tsx
+++ b/src/layouts/CommonLayout.tsx
@@ -142,6 +142,7 @@ const CommonLayout = () => {
           justifyContent: 'center',
           alignItems: 'center',
           position: 'relative',
+          overflow: 'hidden',
         })}
       >
         <Outlet />

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -18,6 +18,7 @@ import {
 import { playSound } from '@/utils/sound';
 import { isTrulyEmptyString } from '@/utils/string';
 import { toastWithSound } from '@/utils/toast';
+import { keepScroll } from '@/utils/ui';
 import { generateId } from '@/utils/user';
 
 type TeamRow = {
@@ -36,13 +37,15 @@ const Create = () => {
 
   const handleAddTeamRow = () => {
     playSound('버튼_클릭');
-    const newTeam: TeamRow = {
-      id: generateId(), // <- 임시. 서버에 보낼때는 제거해야함
-      pmName: '',
-      pmPosition: '',
-      teamName: '',
-    };
-    setTeamRows((prev) => prev.concat(newTeam));
+    keepScroll(() => {
+      const newTeam: TeamRow = {
+        id: generateId(), // <- 임시. 서버에 보낼때는 제거해야함
+        pmName: '',
+        pmPosition: '',
+        teamName: '',
+      };
+      setTeamRows((prev) => prev.concat(newTeam));
+    });
   };
   const handleUpdateTeamRow =
     (id: string) => (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -67,7 +70,7 @@ const Create = () => {
     });
 
     if (isEmptyRow || confirm('입력한 값이 존재합니다.\n삭제하시겠습니까?')) {
-      setTeamRows((prev) => prev.filter((t) => t.id !== id));
+      keepScroll(() => setTeamRows((prev) => prev.filter((t) => t.id !== id)));
     }
   };
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -60,7 +60,13 @@ const Create = () => {
       );
     };
   const handleDeleteTeamRow = (id: string) => () => {
-    if (confirm('삭제하시겠습니까?')) {
+    const row = teamRows.find((t) => t.id === id);
+    const isEmptyRow = Object.entries(row ?? {}).every(([key, value]) => {
+      if (key === 'id') return true;
+      return isTrulyEmptyString(value);
+    });
+
+    if (isEmptyRow || confirm('입력한 값이 존재합니다.\n삭제하시겠습니까?')) {
       setTeamRows((prev) => prev.filter((t) => t.id !== id));
     }
   };

--- a/src/pages/TeamBuilding/Admin.tsx
+++ b/src/pages/TeamBuilding/Admin.tsx
@@ -338,29 +338,37 @@ export const Admin = ({ teamBuildingUuid }: AdminProps) => {
 
   const renderTeamTitle = (teamUuid: Team['uuid']) => {
     const team = teamInfoList?.find((team) => team.uuid === teamUuid);
-    const teamTitle = team ? `${team.pmName} - ${team.teamName}` : '남은 인원';
     const showCheck = team?.selectDone ?? false;
 
     return (
-      <div className={hstack()}>
-        {teamTitle}
-        {showCheck && (
-          <div
-            title="이번 라운드 팀원 선택을 완료했습니다."
-            className={center({
-              width: '28px',
-              height: '28px',
-              borderRadius: '50%',
-              flexShrink: 0,
-              backgroundColor: 'green.70',
-              '& svg': {
-                width: '20px',
-                height: '20px',
-              },
-            })}
-          >
-            <CheckWithoutCircleIcon />
+      <div className={css({ padding: '16px 0', textStyle: 'p2' })}>
+        {team ? (
+          <div className={stack({ gap: '8px' })}>
+            <div className={hstack({ textStyle: 'h4' })}>
+              {team.pmName}
+              {showCheck && (
+                <div
+                  title="이번 라운드 팀원 선택을 완료했습니다."
+                  className={center({
+                    width: '28px',
+                    height: '28px',
+                    borderRadius: '50%',
+                    flexShrink: 0,
+                    backgroundColor: 'green.70',
+                    '& svg': {
+                      width: '20px',
+                      height: '20px',
+                    },
+                  })}
+                >
+                  <CheckWithoutCircleIcon />
+                </div>
+              )}
+            </div>
+            <div>{team.teamName}</div>
           </div>
+        ) : (
+          '남은 인원'
         )}
       </div>
     );

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -544,6 +544,19 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
                   : '이번 라운드에는 지망자가 없습니다'}
               </span>
             )}
+            {!selectListModalProps.isOpen && (
+              <div
+                className={css({
+                  position: 'absolute',
+                  top: '0',
+                  left: '0',
+                  width: '100%',
+                  height: '100%',
+                  cursor: 'pointer',
+                })}
+                onClick={() => selectListModalProps.onOpen()}
+              />
+            )}
           </div>
           <div
             className={css({

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -60,7 +60,10 @@ const ROUNDS = [
 ];
 
 export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
-  const { data, refetch, setTotalInfo } = useGetTotalInfo(teamBuildingUuid);
+  const { data, refetch, setTotalInfo } = useGetTotalInfo(
+    teamBuildingUuid,
+    true,
+  );
   const { teamBuildingInfo, teamInfoList, userInfoList } = data ?? {};
   const { mutateAsync: selectUsers } = useSelectUsers();
   const eventSource = useAtomValue(eventSourceAtom);

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -491,6 +491,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
                 marginTop: '30px',
                 marginRight: '20px',
                 paddingRight: '10px',
+                paddingBottom: '56px',
                 gap: '16px',
                 overflow: 'auto',
                 _scrollbarThumb: {

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -74,6 +74,10 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     return ROUND_INDEX_MAP[teamBuildingInfo?.roundStatus ?? 'FIRST_ROUND'];
   }, [teamBuildingInfo?.roundStatus]);
 
+  const currentRoundLabel = useMemo(() => {
+    return ROUND_LABEL_MAP[teamBuildingInfo?.roundStatus ?? 'FIRST_ROUND'];
+  }, [teamBuildingInfo?.roundStatus]);
+
   const selectDoneList = useMemo(() => {
     return teamInfoList
       ?.filter((team) => team.selectDone)
@@ -84,14 +88,13 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
     firstLine: string;
     secondLine?: string;
   }>(() => {
-    const roundStatus = teamBuildingInfo?.roundStatus ?? 'FIRST_ROUND';
     if (teamBuildingInfo?.roundStatus === 'COMPLETE')
       return { firstLine: '팀 빌딩 완료' };
     else if (selectDoneList?.includes(teamUuid) || activeStep > 3)
-      return { firstLine: ROUND_LABEL_MAP[roundStatus], secondLine: '대기중' };
+      return { firstLine: currentRoundLabel, secondLine: '대기중' };
     else
       return {
-        firstLine: ROUND_LABEL_MAP[roundStatus],
+        firstLine: currentRoundLabel,
         secondLine: '선택 완료하기',
       };
   }, [selectDoneList, teamUuid, activeStep, teamBuildingInfo?.roundStatus]);
@@ -446,12 +449,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
                   color: 'gray.5',
                 })}
               >
-                {
-                  ROUND_LABEL_MAP[
-                    teamBuildingInfo?.roundStatus ?? 'FIRST_ROUND'
-                  ]
-                }{' '}
-                리스트
+                {currentRoundLabel} 리스트
               </h2>
               <div className={css({ width: '123px', height: '44px' })}>
                 <Button

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -407,6 +407,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
           className={css({
             width: '1280px',
             height: '200px',
+            position: 'relative',
             _after: {
               content: '""',
               position: 'fixed',
@@ -426,23 +427,30 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
           <div
             className={stack({
               width: '1030px',
-              height: selectListModalProps.isOpen ? '650px' : '200px',
+              height: '650px',
               background: selectListModalProps.isOpen
                 ? 'rgba(255, 255, 255, 0.07)'
                 : 'rgba(0, 0, 0, 0.07)',
               backdropFilter: 'blur(50px)',
-              padding: '30px 30px 0 30px',
+              padding: '30px 0 0 30px',
               border: '1px solid rgba(255, 255, 255, 0.11)',
               borderRadius: '20px 20px 0 0',
               overflow: 'auto',
               position: 'absolute',
-              bottom: '0',
+              top: selectListModalProps.isOpen ? '-450px' : '0', // -450px = 650px(전체 높이) - 200px(부모 높이)
+              left: '0',
               gap: '0',
-              transition: 'height 0.3s ease-in-out',
+              transition: 'top 0.3s ease-in-out',
+              willChange: 'top',
               zIndex: '1',
             })}
           >
-            <div className={hstack({ justifyContent: 'space-between' })}>
+            <div
+              className={hstack({
+                justifyContent: 'space-between',
+                paddingRight: '30px',
+              })}
+            >
               <h2
                 className={css({
                   textStyle: 'h1',
@@ -481,6 +489,8 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
               className={grid({
                 columns: 4,
                 marginTop: '30px',
+                marginRight: '20px',
+                paddingRight: '10px',
                 gap: '16px',
                 overflow: 'auto',
                 _scrollbarThumb: {

--- a/src/pages/TeamBuilding/Player.tsx
+++ b/src/pages/TeamBuilding/Player.tsx
@@ -287,7 +287,7 @@ export const Player = ({ teamUuid, teamBuildingUuid }: PlayerProps) => {
                 color: 'gray.5',
               })}
             >
-              Nexters23기 팀빌딩입니다
+              {teamBuildingInfo?.teamBuildingName}
             </h1>
             <button
               className={css({

--- a/src/pages/TeamBuilding/TeamBuilding.tsx
+++ b/src/pages/TeamBuilding/TeamBuilding.tsx
@@ -6,6 +6,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { BASE_URL } from '@/apis/http';
 import { useGetTotalInfo } from '@/apis/team-building/queries';
 import Spinner from '@/components/Spinner';
+import { useBeforeUnload } from '@/hooks/useBeforeUnload';
 import { eventSourceAtom } from '@/store/atoms';
 import { Team } from '@/types';
 import { resolveUrl } from '@/utils/url';
@@ -43,6 +44,8 @@ const TeamBuilding = () => {
     setEventSource(eventSource);
     return () => eventSource.close();
   }, [setEventSource, teamBuildingUuid]);
+
+  useBeforeUnload(role !== null);
 
   if (isLoading) return <Spinner />;
   if (!teamBuildingUuid || !totalInfo) return <NotFound />;

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 
 export const initSentry = () => {
   Sentry.init({
-    dsn: import.meta.env.VITE_SENTRY_DSN,
+    dsn: import.meta.env.PROD ? import.meta.env.VITE_SENTRY_DSN : undefined,
     integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
     // Performance Monitoring
     tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -1,0 +1,20 @@
+export const keepScroll = (callback: () => void) => {
+  const scrollHeightBefore = document.documentElement.scrollHeight;
+
+  callback();
+
+  Promise.resolve().then(() => {
+    const scrollHeightAfter = document.documentElement.scrollHeight;
+    const diff = scrollHeightAfter - scrollHeightBefore;
+    const isScrollAtBottom =
+      Math.abs(
+        window.innerHeight + window.scrollY - document.body.scrollHeight,
+      ) < 1;
+
+    // @note: 화면이 더 길어지거나, 스크롤이 맨 아래에 있지 않는 경우
+    // 마우스 포인터가 동일한 요소를 가리키도록 하고자 스크롤 위치를 조절한다.
+    if (diff >= 0 || !isScrollAtBottom) {
+      window.scrollTo(0, window.scrollY + diff);
+    }
+  });
+};


### PR DESCRIPTION
## 작업 내용

- 비어있는 열은 바로 삭제되도록
  - 삭제버튼 누를때 귀찮아서
- 열 추가, 삭제마다 포인터가 밀리지 않도록
  - 성인쓰가 제보한 이슈를 이런식으로 풀었는데 맞는 방식인지는 잘 몰루?
- 개발 중 에러는 센트리에 넘어가지 않도록
- 실수로 새로고침했을때 방지 추가
  - 뒤로가기 누를때 방어가 없어서 추가
- 플레이어 페이지에서 polling 추가
  - 요게 빠져있어서 라운드 끝난거 이벤트 전파 못받았어도 polling을 안하더라구
  - 그래서 추가함
- 서버에서 가져온 팀빌딩 제목 보이게
  - 하드코딩 되어있었음..ㅋㅋ
- 어드민 페이지도 전체현황 페이지처럼 팀이름 보이게
- 라운드 라벨 하나의 변수에서 사용하도록
- 스크롤이 딱 붙어있지 않도록 + height 변경으로 브라우저 최대한 버벅거리지 않게
  - 스크롤이 카드에 너무 붙어있어서 margin + padding으로 적절히 띄워두었음!
  - height 변경되다보니 스크롤바 크기가 트랜지션동안 동적으로 변경되서 이거 변경해봄
- 리스트 닫혀있을때는 펼쳐야지만 선택 가능하도록
  - 성인쓰가 제안한건데 선택할 수 있는 카드 리스트 영역이 닫혀있을땐 스크롤도 안되고 개별 카드 클릭도 안되고 오직 펼쳐지게만 하게 제안했어서 그거 반영해봄 

## 체크리스트

- [ ] Code Review 요청
- [ ] Label 설정
- [ ] PR 제목 규칙에 맞는지 확인
